### PR TITLE
feat: splash, login, setting 기능 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,6 +34,9 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
+    buildFeatures {
+        viewBinding = true
+    }
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,14 +14,25 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.DayBreak"
         android:usesCleartextTraffic="true">
+
         <activity
-            android:name=".MainActivity"
+            android:name=".SplashActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".LoginActivity"
+            android:exported="true">
+        </activity>
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="false">
         </activity>
     </application>
 

--- a/app/src/main/java/com/example/daybreak/LoginActivity.kt
+++ b/app/src/main/java/com/example/daybreak/LoginActivity.kt
@@ -1,7 +1,101 @@
 package com.example.daybreak
 
+import android.content.Intent
+import android.os.Bundle
+import android.text.Editable
+import android.text.InputType
+import android.text.TextWatcher
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import com.example.daybreak.databinding.ActivityLoginBinding
 
 class LoginActivity : AppCompatActivity() {
+    lateinit var binding: ActivityLoginBinding
 
+    override fun onCreate(savedInstanceState: Bundle?){
+        super.onCreate(savedInstanceState)
+        binding = ActivityLoginBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setupFocusListeners()
+        setupClickListeners()
+        setopTextWatchers()
+    }
+    //비번 보이는 상태인지 저장하는 함수
+    private var isPasswordVisible = false
+    private fun setupFocusListeners(){
+        //id입력창
+        binding.loginIdEt.setOnFocusChangeListener{_, hasFocus->
+            if(hasFocus){
+                binding.loginIdIv.visibility = View.VISIBLE
+            } else{
+                binding.loginIdIv.visibility = View.GONE
+            }
+        }
+
+        binding.loginPwdEt.setOnFocusChangeListener{_, hasFocus->
+            if (hasFocus) {
+                // 포커스 받으면 현재 상태에 맞는 아이콘 하나만 표시
+                updatePasswordIcon()
+            } else {
+                binding.loginPwdEyeIv.visibility = View.GONE
+                binding.loginPwdCloseEyeIv.visibility = View.GONE
+            }
+        }
+    }
+
+    private fun setupClickListeners(){
+        val toggleAction = View.OnClickListener{
+            isPasswordVisible = !isPasswordVisible //상태 반전
+
+            if(isPasswordVisible){
+                // 비번 보이기
+                binding.loginPwdEt.inputType = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
+            } else {
+                // 비번 가리기
+                binding.loginPwdEt.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+            }
+            //비밀번호 모드를 바꾸면 커서가 맨앞으로 가버리는걸 뒤로 보내버리기
+            binding.loginPwdEt.setSelection(binding.loginPwdEt.text.length)
+
+            updatePasswordIcon()
+        }
+
+        binding.loginPwdEyeIv.setOnClickListener(toggleAction)
+        binding.loginPwdCloseEyeIv.setOnClickListener(toggleAction)
+
+        binding.loginLoginBtn.setOnClickListener {
+            val intent = Intent(this, MainActivity::class.java)
+            startActivity(intent)
+            finish()
+        }
+    }
+    //  상태에 따라 아이콘 보이거나 없어지는거
+    private fun updatePasswordIcon() {
+        if (isPasswordVisible) {
+            binding.loginPwdEyeIv.visibility = View.VISIBLE
+            binding.loginPwdCloseEyeIv.visibility = View.GONE
+        } else {
+            binding.loginPwdEyeIv.visibility = View.GONE
+            binding.loginPwdCloseEyeIv.visibility = View.VISIBLE
+        }
+    }
+
+    private fun setopTextWatchers(){
+        val watcher = object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int){}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                // 아이디와 비밀번호가 모두 입력되었는지 확인
+                val idText = binding.loginIdEt.text.toString()
+                val pwdText = binding.loginPwdEt.text.toString()
+
+                // 둘 다 비어있지 않으면 버튼 활성화
+                val isEnabled = idText.isNotEmpty() && pwdText.isNotEmpty()
+                binding.loginLoginBtn.isEnabled = isEnabled // XML의 버튼 ID가 loginBtn이라 가정
+            }
+            override fun afterTextChanged(s: Editable?) {}
+        }
+        binding.loginIdEt.addTextChangedListener(watcher)
+        binding.loginPwdEt.addTextChangedListener(watcher)
+    }
 }

--- a/app/src/main/java/com/example/daybreak/PopUpDialogFragment.kt
+++ b/app/src/main/java/com/example/daybreak/PopUpDialogFragment.kt
@@ -1,0 +1,52 @@
+package com.example.daybreak
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.example.daybreak.databinding.FragmentPopUpDialogBinding
+
+class PopUpDialogFragment : DialogFragment() {
+    private var _binding: FragmentPopUpDialogBinding? = null
+    private val binding get() = _binding!!
+
+    // 클릭 리스너를 저장하는 변수
+    private var confirmAction:(() -> Unit)? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentPopUpDialogBinding.inflate(inflater, container, false)
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.dialogTitle1.text = arguments?.getString("title")
+        binding.dialogTitle2.text = arguments?.getString("subtitle")
+        binding.dialogButton2.text = arguments?.getString("btntext")
+        //취소버튼
+        binding.dialogButton1.setOnClickListener { //dismiss() }
+            // 로그아웃/탈퇴 버튼
+            binding.dialogButton2.setOnClickListener {
+                confirmAction?.invoke() //
+                dismiss()
+            }
+        }
+
+        fun setOnConfirmClickListener(action: () -> Unit) {
+            this.confirmAction = action
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+}

--- a/app/src/main/java/com/example/daybreak/SettingFragment.kt
+++ b/app/src/main/java/com/example/daybreak/SettingFragment.kt
@@ -1,7 +1,48 @@
 package com.example.daybreak
 
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.example.daybreak.databinding.FragmentSettingBinding
 
 class SettingFragment : Fragment() {
+    private lateinit var binding: FragmentSettingBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentSettingBinding.inflate(inflater,container,false)
+
+        binding.settingLogoutTv.setOnClickListener {
+            val dialog = PopUpDialogFragment().apply {
+                arguments = Bundle().apply {
+                    putString("title", "계정에서 로그아웃 하시겠어요?")
+                    putString("subtitle","언제든지 다시 돌아올 수 있어요.")
+                    putString("btntext","로그아웃")
+                }
+            }
+
+
+            dialog.show(childFragmentManager,"Dialogtag")
+        }
+
+        binding.settingDropOutTv.setOnClickListener {
+            val dialog = PopUpDialogFragment().apply {
+                arguments = Bundle().apply {
+                    putString("title", "계정을 삭제하시는 건가요?")
+                    putString("subtitle", "한번 삭제된 계정은 되돌릴 수 없어요.")
+                    putString("btntext", "그래도 탈퇴")
+                }
+            }
+
+            dialog.show(childFragmentManager, "Dialogtag")
+        }
+
+        return binding.root
+    }
 
 }

--- a/app/src/main/java/com/example/daybreak/SplashActivity.kt
+++ b/app/src/main/java/com/example/daybreak/SplashActivity.kt
@@ -1,0 +1,24 @@
+package com.example.daybreak
+
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+
+class SplashActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?){
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContentView(R.layout.activity_splash)
+
+        Handler(Looper.getMainLooper()).postDelayed({
+            val intent = Intent(this, LoginActivity::class.java)
+
+            startActivity(intent)
+
+            finish()
+        }, 2000)
+    }
+}

--- a/app/src/main/res/drawable/edittext_focus_background.xml
+++ b/app/src/main/res/drawable/edittext_focus_background.xml
@@ -3,8 +3,8 @@
     <!--포커스상태-->
     <item android:state_focused="true">
         <shape android:shape="rectangle">
-            <solid android:color="@color/colorinsidegray300" />
-            <stroke android:width="1.5dp" android:color="#F1EFEB" />
+            <solid android:color="@color/colorbackground" />
+            <stroke android:width="1dp" android:color="#F1EFEB" />
             <corners android:radius="12dp" />
         </shape>
     </item>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -87,6 +87,7 @@
             android:background="@null"/>
 
         <ImageView
+            android:id="@+id/login_id_iv"
             android:layout_width="32dp"
             android:layout_height="32dp"
             android:src="@drawable/ic_clear_32"
@@ -117,22 +118,29 @@
             android:background="@null"/>
         
         <ImageView
+            android:id="@+id/login_pwd_close_eye_iv"
             android:layout_width="32dp"
             android:layout_height="32dp"
             android:src="@drawable/ic_eye_close_32"
             android:layout_marginStart="8dp"
+            android:clickable="true"
+            android:focusable="true"
             android:visibility="gone"/>
 
         <ImageView
+            android:id="@+id/login_pwd_eye_iv"
             android:layout_width="32dp"
             android:layout_height="32dp"
             android:src="@drawable/ic_option_open_32"
             android:layout_marginStart="8dp"
+            android:clickable="true"
+            android:focusable="true"
             android:visibility="gone"/>
 
     </LinearLayout>
 
     <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/login_login_btn"
         style="@style/wantedSans_semibold_14sp_inside_login"
         android:layout_width="320dp"
         android:layout_height="56dp"

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="@color/colorblack">
+
+    <ImageView
+        android:id="@+id/splash_small_ic_iv"
+        android:src="@drawable/img_symbols_default"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="272dp"
+        android:layout_width="68dp"
+        android:layout_height="14dp"/>
+    
+    <ImageView
+        android:id="@+id/splash_main_logo_iv"
+        android:src="@drawable/img_logo_light"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginTop="302dp"
+        android:layout_width="184.3723dp"
+        android:layout_height="40dp"/>
+
+    <TextView
+        style="@style/wantedSans_regular_14sp_gray_body"
+        android:id="@+id/splash_tv"
+        android:text="하루를 조금씩 깨워, 미래에 닿다"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginTop="354dp"
+        android:layout_width="180dp"
+        android:layout_height="23dp"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_pop_up_dialog.xml
+++ b/app/src/main/res/layout/fragment_pop_up_dialog.xml
@@ -60,7 +60,7 @@
                 android:layout_width="128dp"
                 android:layout_height="48dp"
                 android:background="@drawable/dialog_button_background_gray"
-                android:text="제목없음"/>
+                android:text="취소"/>
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/dialog_button2"

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -174,19 +174,13 @@
             android:layout_marginStart="12dp">
 
             <TextView
+                android:id="@+id/setting_logout_tv"
                 style="@style/wantedSans_semibold_14sp_inside_login"
                 android:layout_width="55dp"
                 android:layout_height="22dp"
                 android:text="로그아웃"
                 android:layout_marginStart="12dp"
                 android:layout_marginTop="12dp"/>
-
-            <ImageView
-                android:layout_width="20dp"
-                android:layout_height="20dp"
-                android:src="@drawable/ic_chevron_right_light_32"
-                android:layout_marginTop="12dp"
-                android:layout_marginStart="200dp"/>
 
         </LinearLayout>
 
@@ -197,6 +191,7 @@
             android:layout_marginStart="12dp">
 
             <TextView
+                android:id="@+id/setting_drop_out_tv"
                 style="@style/wantedSans_semibold_14sp_inside_del"
                 android:layout_width="55dp"
                 android:layout_height="22dp"


### PR DESCRIPTION
# 📌 Pull Request Title
> splash, login, setting 기능 구현
> 


---

# ✨ 작업 내용 (What)
> splash화면 2초 지나면 login화면으로 일단 넘어가게 해놨고요
> setting에서 로그아웃, 탈퇴 누르면 dialog나오게 했습니다
> 
> 


---

# 🧪 테스트 방법 (How to Test)
> - 앱 실행 → 로그인 이동 → ID/PW 입력 시 UI 정상 동작 확인

---

# 💡추가 사항
> 추가로 작성할 것이 있다면 여기에 작성해주세요!
> 근데 아직 메인에서 setting으로 넘어가는건 안되어있어서 그대로 두었고 dialog나오는건 테스트해봤습니다
---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: #00
